### PR TITLE
Ignore .metals and .bloop. Minor change to CDR blueprint.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ project/activator-sbt*
 # vim swap files
 *.swp
 .*.swp
+
+# Scala Metals
 .metals/
 .bloop/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ project/activator-sbt*
 # vim swap files
 *.swp
 .*.swp
+.metals/
+.bloop/

--- a/call-record-aggregator/.gitignore
+++ b/call-record-aggregator/.gitignore
@@ -20,9 +20,9 @@ project/activator-sbt*
 *.iml
 *.iws
 
-# Metals
-.bloop/
+# Scala Metals
 .metals/
+.bloop/
 
 # Mac
 .DS_Store

--- a/call-record-aggregator/.gitignore
+++ b/call-record-aggregator/.gitignore
@@ -20,6 +20,10 @@ project/activator-sbt*
 *.iml
 *.iws
 
+# Metals
+.bloop/
+.metals/
+
 # Mac
 .DS_Store
 

--- a/call-record-aggregator/call-record-pipeline/src/main/blueprint/blueprint.conf
+++ b/call-record-aggregator/call-record-pipeline/src/main/blueprint/blueprint.conf
@@ -1,9 +1,9 @@
 blueprint {
   streamlets {
+    cdr-ingress = pipelines.examples.carly.ingestor.CallRecordIngress
     cdr-generator1 = pipelines.examples.carly.aggregator.CallRecordGeneratorIngress
     cdr-generator2 = pipelines.examples.carly.aggregator.CallRecordGeneratorIngress
     merge = pipelines.examples.carly.ingestor.CallRecordMerge
-    cdr-ingress = pipelines.examples.carly.ingestor.CallRecordIngress
     cdr-validator = pipelines.examples.carly.ingestor.CallRecordValidation
     cdr-aggregator = pipelines.examples.carly.aggregator.CallStatsAggregator
     console-egress = pipelines.examples.carly.output.AggregateRecordEgress

--- a/sensor-data-java/.gitignore
+++ b/sensor-data-java/.gitignore
@@ -27,4 +27,8 @@ project/activator-sbt*
 *.swp
 .*.swp
 
+# Scala Metals
+.metals/
+.bloop/
+
 target-env.sbt

--- a/sensor-data-scala/.gitignore
+++ b/sensor-data-scala/.gitignore
@@ -27,4 +27,8 @@ project/activator-sbt*
 *.swp
 .*.swp
 
+# Scala Metals
+.metals/
+.bloop/
+
 target-env.sbt

--- a/spark-resilience-test/.gitignore
+++ b/spark-resilience-test/.gitignore
@@ -27,4 +27,8 @@ project/activator-sbt*
 *.swp
 .*.swp
 
+# Scala Metals
+.metals/
+.bloop/
+
 target-env.sbt

--- a/spark-sensors/.gitignore
+++ b/spark-sensors/.gitignore
@@ -27,4 +27,8 @@ project/activator-sbt*
 *.swp
 .*.swp
 
+# Scala Metals
+.metals/
+.bloop/
+
 target-env.sbt


### PR DESCRIPTION
Modified `.gitignore` files to ignore the Scala Metals directories, `.bloop` and `.metals`. Also moved a line in the CDR `blueprints.conf` so order better matches how they are seen in the Pipelines UI (left to right), for reasons of a presentation I prepared..